### PR TITLE
#4 adding vn civilian cars

### DIFF
--- a/Missionframework/presets/civilians/vn.sqf
+++ b/Missionframework/presets/civilians/vn.sqf
@@ -41,5 +41,14 @@ civilians = [
 // Civilian vehicle classnames.
 civilian_vehicles = [
     "vn_c_bicycle_01",
-    "vn_c_bicycle_02"
+    "vn_c_bicycle_02",
+    "vn_c_bicycle_01",
+    "vn_c_bicycle_02",
+    "vn_c_bicycle_01",
+    "vn_c_bicycle_02",
+    "vn_c_car_01_01",
+    "vn_c_car_02_01",
+    "vn_c_car_03_01",
+    "vn_c_car_01_02",
+    "vn_c_car_04_01"
 ];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| Needs wipe? | no |

### Description:

Added "vn_c_car_01_01",
    "vn_c_car_02_01",
    "vn_c_car_03_01",
    "vn_c_car_01_02",
    "vn_c_car_04_01" to the civilian vehicles  but kept the ratio 6 bicycles to 5 cars.
   
Having civilian cars on the map creates the challenge of identifying before engaging a vehicle esp. at night or from air assets.

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP